### PR TITLE
Promise return option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ dialog-node is providing developers an easy cross platform way to use interactiv
 
 * no external dependencies since dialog-node does all the UI dialogs with onboard tools
 * low memory foot print, important for IoT platforms like Raspberry
-* low CPU consumption 
+* low CPU consumption
 
 ## Installation
 
@@ -31,7 +31,7 @@ This test will run through all available dialogs with some example settings
 
 ### Example (see also example.js)
 
-```
+```js
 var dialog = require('dialog-node');
 
 //will be called after user closes the dialog
@@ -64,12 +64,13 @@ directory = location of mode_modules folder that includes dialog-node
 
 ### Parameter for all dialogs
 ```
-dialog-node.<dialog>(msg, title, timeout, callback);
+promise = dialog-node.<dialog>(msg, title, timeout, callback);
 
 msg      = string containing specific dialog message
 title    = string containing title of dialog (this parameter is not observed for all dialogs)
 timeout  = dialog is timing out after <timeout> seconds, if parameter is 0 dialog does not time out
 callback = to be called after user closes dialog, for further description see further below
+promise  = resolves to the return value or an Error object with "stderr" as the message and any exit code as its `code` property
 ```
 
 ### info
@@ -96,7 +97,7 @@ dialog-node.error(msg, title, timeout, callback);
 
 ### question
 
-A dialog that displays text and title and that prompts user to click a Cancel or an OK button. OK is the default answer. 
+A dialog that displays text and title and that prompts user to click a Cancel or an OK button. OK is the default answer.
 
 ```
 dialog-node.question(msg, title, timeout, callback);
@@ -134,7 +135,7 @@ Returns the date the user selected as a string handed into the callback function
 
 ### file select
 
-Prompts user to select a file. 
+Prompts user to select a file.
 
 ```
 dialog-node.fileselect(msg, title, timeout, callback);
@@ -152,7 +153,7 @@ dialog-nodes are non-blocking and call a callback function after the user action
 ```
 function(code, retVal, stderr)
 
-code = return code from dialog 
+code = return code from dialog
 retVal = user's response as a string
 stderr = any error information that the dialog created
 ```
@@ -161,7 +162,7 @@ stderr = any error information that the dialog created
 
 ## Known Bugs / Issues
 
-* timeout not a functional parameter for some dialogs (i.e. file select) 
+* timeout not a functional parameter for some dialogs (i.e. file select)
 
 ## Authors
 
@@ -175,5 +176,3 @@ This project is licensed under the MIT License -
 
 * Tomás Pollak for the inspiration and elegant but short dialog code, see also https://github.com/tomas/dialog
 * OSX date picker from Shane Stanley, modified by Christopher Stone, see also https://forum.keyboardmaestro.com/t/feature-request-date-picker-in-prompt-for-user-action/3281
-
-

--- a/datepicker.osa
+++ b/datepicker.osa
@@ -12,7 +12,7 @@ my datePicker()
 
 on datePicker()
 	set theApp to path to frontmost application as text
-	
+
 	if not (current application's NSThread's isMainThread()) as boolean then
 		display alert "This script must be run from the main thread." buttons {"Cancel"} as critical
 		error number -128
@@ -27,7 +27,7 @@ on datePicker()
 	#datePicker's setDatePickerStyle:(current application's NSTextFieldDatePickerStyle)
 	-- set elements: choices include NSHourMinuteDatePickerElementFlag, NSHourMinuteSecondDatePickerElementFlag, NSTimeZoneDatePickerElementFlag, NSYearMonthDatePickerElementFlag, and NSEraDatePickerElementFlag
 	datePicker's setDatePickerElements:((current application's NSYearMonthDayDatePickerElementFlag) + (current application's NSHourMinuteSecondDatePickerElementFlag as integer))
-	
+
 	-- set initial date
 	#datePicker's setDateValue:(current application's NSDate's |date|())
 	--set theCal var to a new(empty) instance of the calendar
@@ -41,7 +41,7 @@ on datePicker()
 	theComponents's setMonth:4
 	theComponents's setDay:1
 	datePicker's setDateValue:(theCal's dateFromComponents:theComponents)
-	
+
 	-- get the size it needs
 	set theSize to datePicker's fittingSize()
 	--resize the picker and view accordingly
@@ -59,7 +59,7 @@ on datePicker()
 		its addButtonWithTitle:"Cancel"
 		its setAccessoryView:theView
 	end tell
-	
+
 	-- show alert in modal loop
 	set returnCode to theAlert's runModal()
 	if returnCode = (current application's NSAlertSecondButtonReturn) then error number -128
@@ -79,7 +79,7 @@ on datePicker()
 	set day of theDate to theComponents's |day|()
 	set hours of theDate to theComponents's hour()
 	set minutes of theDate to theComponents's minute()
-	
+
 	return (theDate as text)
 	#return (theDate)
 end datePicker

--- a/example.js
+++ b/example.js
@@ -1,9 +1,20 @@
+'use strict';
 var dialog = require('../dialog-node');
 
 //will be called after user closes the dialog
 var callback = function(code, retVal, stderr)
 {
 	console.log("return value = <" + retVal + ">");
-}
+};
 
+// dialog.setCwd(__dirname);
 dialog.fileselect('Type some text', "entry prompt", 0, callback);
+
+/*
+(async () => {
+
+const retVal = await dialog.entry('Type some text', "entry prompt");
+console.log("return2 value = <" + retVal + ">");
+
+})();
+*/

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var join = require('path').join,
     spawn = require('child_process').spawn,
     os = require('os');
@@ -37,6 +39,9 @@ var dialogNode = module.exports = {
   },
 
   info: function(str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -51,6 +56,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
 
     }
@@ -67,6 +73,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
 
     }
@@ -82,13 +89,17 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   warn: function(str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -103,6 +114,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
 
     }
@@ -119,6 +131,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
@@ -134,13 +147,17 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   error: function(str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -156,6 +173,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if( OS === "darwin")
@@ -170,6 +188,7 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
@@ -184,13 +203,17 @@ var dialogNode = module.exports = {
       cb = function(code, stdout, stderr){
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   question: function( str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -208,6 +231,7 @@ var dialogNode = module.exports = {
           retVal = OK_STR;
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if( OS === "darwin")
@@ -225,6 +249,7 @@ var dialogNode = module.exports = {
           retVal = OK_STR;
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
@@ -243,13 +268,16 @@ var dialogNode = module.exports = {
           retVal = CANCEL_STR;
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   entry: function( str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
     this.init();
     if( OS === "linux")
     {
@@ -265,6 +293,7 @@ var dialogNode = module.exports = {
         retVal = stdout.slice(0,-1);
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if( OS === "darwin")
@@ -289,6 +318,7 @@ var dialogNode = module.exports = {
 
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
@@ -304,13 +334,17 @@ var dialogNode = module.exports = {
         retVal = stdout;
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   calendar: function( str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -326,6 +360,7 @@ var dialogNode = module.exports = {
         retVal = stdout.slice(0,-1);
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if( OS === "darwin")
@@ -337,18 +372,21 @@ var dialogNode = module.exports = {
         retVal = stdout.slice(0,-1);
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
     {
-      this.entry( str, title, timeout, callback);
-      return
+      return this.entry( str, title, timeout, callback);
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   fileselect: function( str, title, timeout, callback){
+    var cb;
+    timeout = timeout || 0;
+
     this.init();
     if( OS === "linux")
     {
@@ -364,6 +402,7 @@ var dialogNode = module.exports = {
         retVal = stdout.slice(0,-1);
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if( OS === "darwin")
@@ -381,6 +420,7 @@ var dialogNode = module.exports = {
 
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
     else if (OS === "win32")
@@ -396,10 +436,11 @@ var dialogNode = module.exports = {
         retVal = stdout;
         if(callback)
           callback(code, retVal, stderr);
+        return retVal;
       }
     }
 
-    this.run(cmd, cb, callback);
+    return this.run(cmd, cb, callback);
   },
 
   debugprint: function(cmd,args,cb){
@@ -415,32 +456,51 @@ var dialogNode = module.exports = {
         args = cmd.splice(1),
         stdout = '', stderr = '';
 
-    try {
-      var child = spawn(bin, args, {cwd:cwd});
-    } catch (err) {
-        console.log('spawn failed : ' + err.message);
-    }
+    return new Promise(function (resolve, reject) {
+      try {
+        var child = spawn(bin, args, {cwd:cwd});
+      } catch (err) {
+          console.log('spawn failed : ' + err.message);
+      }
 
-    var stdoutlines = 0;
+      var stdoutlines = 0;
 
-    //this.debugprint(cmd,args,callback);
+      //this.debugprint(cmd,args,callback);
 
-    child.stdout.on('data', function(data){
-      stdout += data.toString();
-      stdoutlines++;
-    })
+      child.stdout.on('data', function(data){
+        stdout += data.toString();
+        stdoutlines++;
+      })
 
-    child.stderr.on('data', function(data){
-      stderr += data.toString();
-    })
+      child.stderr.on('data', function(data){
+        stderr += data.toString();
+      })
 
-    child.on('error', function(error){
-      console.log("dialog-node, error = ", error);
+      child.on('error', function(error){
+        console.log("dialog-node, error = ", error);
+      });
+
+      child.on('exit', function(code){
+        var retVal = cb && cb(code, stdout, stderr, callback);
+        if (
+          // Avoid treating as error (even with exit code 1, for cancel)
+          stderr.indexOf('User canceled') === -1 &&
+          (
+            code || (
+              // Avoid treating as error for fileselect response warning
+              stderr &&
+              stderr.indexOf('Class FIFinderSyncExtensionHost is implemented') === -1
+            )
+          )
+        ) {
+          var err = new Error(stderr || '');
+          err.code = code;
+          reject(err);
+          return;
+        }
+        resolve(retVal);
+      })
     });
-
-    child.on('exit', function(code){
-      cb && cb(code, stdout, stderr, callback);
-    })
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "email": "truge@blueaspentech.com",
     "url": "http://www.blueaspentech.com"
   },
-  "license": {
-    "license": "MIT"
-  },
+  "contributors": [
+    "Brett Zamir"
+  ],
+  "license": "MIT",
   "main": "index.js",
   "keywords": [
     "dialogs",


### PR DESCRIPTION
- Fix: Avoid global `cb`
- Enhancement: Promise return option (fixes #5)
- Enhancement: Default to timeout of 0
- Optimization: Add `use strict` directive
- Docs: Syntax highlight example
- npm: Fix: `license` and add recommended `contributors` property

I could not get `calendar` working, however.  If I add a `display alert` before the modal code, it can get the datepicker to display, but not otherwise. I searched and found something about `performSelectorOnMainThread` but could not get that to work either (for what I tried).