### PR TITLE
fixes error when trying to package using pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "email": "truge@blueaspentech.com",
     "url": "http://www.blueaspentech.com"
   },
-  "license": {
-    "license": "MIT"
-  },
+  "license": "MIT",
   "main": "index.js",
   "keywords": [
     "dialogs",


### PR DESCRIPTION
currently, when building on macos with `pkg` I get the following error:

```
> pkg@4.4.0
> Error! TypeError: license.toLowerCase is not a function
    at isPublic (/Users/aworcester/github/hudpad/node_modules/pkg/lib-es5/walker.js:61:21)
    at /Users/aworcester/github/hudpad/node_modules/pkg/lib-es5/walker.js:317:23
    at Generator.next (<anonymous>)
    at asyncGeneratorStep (/Users/aworcester/github/hudpad/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/Users/aworcester/github/hudpad/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
error Command failed with exit code 2.
```

making this change in my local `node_modules` fixes the issue.