### PR TITLE
Use file selection dialog instead of FolderSelectionDialog.

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,6 +378,7 @@ var dialogNode = module.exports = {
         //parse return from appl script code
         var findstr = "text returned:";
         retVal = stdout.slice(stdout.indexOf("text returned:") + findstr.length, -1);
+        retVal = retVal.substr(5).replace(/:/g, "/");
 
         if(callback)
           callback(code, retVal, stderr);

--- a/msgbox.vbs
+++ b/msgbox.vbs
@@ -1,6 +1,6 @@
 Function BrowseForFile( dialogText )
   Dim shell : Set shell = CreateObject("Shell.Application")
-  Dim file : Set file = shell.BrowseForFolder(0, dialogTitle, 0)
+  Dim file : Set file = shell.BrowseForFolder(0, dialogTitle, 16384)
   BrowseForFile = file.self.Path
 End Function
 


### PR DESCRIPTION
Per the Microsoft documentation, you need to set the options to allow browsing for files:

https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/ns-shlobj_core-browseinfoa
BIF_BROWSEINCLUDEFILES (0x00004000)


Otherwise, files aren't shown, and can't be selected.